### PR TITLE
Fix typo in Moretrees support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -399,7 +399,7 @@ function capitate_funcs.moretrees(pos, tr, _, digger)
 	local maxx = pos.x+tr.range
 	local minz = pos.z-tr.range
 	local maxz = pos.z+tr.range
-	local maxy = pos.z+tr.height
+	local maxy = pos.y+tr.height
 	local num_trunks = 0
 	local num_leaves = 0
 	local ps = get_tab({x=pos.x, y=pos.y+1, z=pos.z}, function(pos)


### PR DESCRIPTION
Moretrees behavior was different, depending on where in the world I was.  Found that maxy was using pos.z instead of pos.y